### PR TITLE
Use `env python2` instead of `env python`

### DIFF
--- a/pynailgun/ng.py
+++ b/pynailgun/ng.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright 2004-2015, Martian Software, Inc.
 #


### PR DESCRIPTION
My system is configured to use Python 3 by default. Not for any
particular reason, though it seems to be some sort of default.
Consequently, the nailgun script fails with an error when attempting to
run it with Python 3.

I've changed the she-bang line in the script to explicitly use
`python2` instead of the default `python`. I have no idea if this is a
good idea, though, but I offer this one-byte PR as an incentive for
someone to find out.