### PR TITLE
Flush output after each chunk

### DIFF
--- a/pynailgun/ng.py
+++ b/pynailgun/ng.py
@@ -569,6 +569,7 @@ class NailgunConnection(object):
             if dest_file:
                 data = self.buf[:bytes_received].decode("utf-8")
                 dest_file.write(data)
+                dest_file.flush()
             bytes_read += bytes_received
 
 


### PR DESCRIPTION
By default when Python's stdout is piped to another process instead
of printed directly to a terminal, it switches to buffered mode. This
makes it difficult to integrate Bloop in shell scripts or other tools.
Those tools could set `PYTHONUNBUFFERED` environment variable instead,
but for human users it's inconvenient if they want to e.g. pipe
Bloop's output to `grep`, `less` or some other common tool. Thus, we flush
output after every chunk received from the server, which should be
a decent trade-off between convenience and performance (after all, if
it was important/large enough to flush network buffers, then it's
definitely important/large enough to flush stdout).

@propensive might be interested in this.