### PR TITLE
Remove duplicated JVM options

### DIFF
--- a/pynailgun/ng.py
+++ b/pynailgun/ng.py
@@ -1121,14 +1121,13 @@ def main():
             except CalledProcessError as e:
                 # Works in systems such as Mac OS or Nix that in which blp-server is a script
                 try:
-                    jvm_options_with_prefix = [ "-J" + opt for opt in jvm_options_no_prefix ]
                     print("Running " + server_location + " as a script...")
                     if platform.system() == "Windows":
-                        cmd = ["cmd.exe", "/C", server_location] + cmd_args + jvm_options_with_prefix
+                        cmd = ["cmd.exe", "/C", server_location] + cmd_args
                         print("Shelling out in Windows with " + str(cmd))
                         check_call(cmd)
                     else:
-                        cmd = ["sh", server_location] + cmd_args + jvm_options_with_prefix
+                        cmd = ["sh", server_location] + cmd_args
                         print("Shelling out in Unix system with " + str(cmd))
                         check_call(cmd)
                 except CalledProcessError as e2:


### PR DESCRIPTION
Fix https://github.com/scalacenter/bloop/issues/950

`cmd_args` already contains orignal JVM options. We don't need to recostruct `jvm_options_with_prefix` from `jvm_options_no_prefix` since [`jvm_options_no_prefix` also came from `cmd_args`](https://github.com/scalacenter/nailgun/blob/9327a60a2109c0ae5fca9389e2f7d34edf11aee4/pynailgun/ng.py#L1109-L1114).