### PR TITLE
Don't print unnecessary stacktraces in console

### DIFF
--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGServer.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGServer.java
@@ -493,7 +493,7 @@ public class NGServer implements Runnable {
             // an exception will be thrown that we don't care about.  filter
             // those out.
             if (!shutdown.get()) {
-                t.printStackTrace();
+                LOG.warn("Caught exception during accept", t);
             }
         }
         if (sessionOnDeck != null) {

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
@@ -305,7 +305,6 @@ public class NGSession extends Thread {
 
             } catch (Throwable t) {
                 LOG.warn("Internal error in session", t);
-                t.printStackTrace();
             }
 
             ((ThreadLocalInputStream) System.in).init(null);


### PR DESCRIPTION
These tend to pop up more often with domain sockets, which is problem (like we get them everytime we run a `bloop …` command).

Enabling debug logging in bloop allows to recover them if necessary.